### PR TITLE
Reduce allocations of buffer for reused readers

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -33,7 +33,13 @@ func NewReader(src io.Reader) *Reader {
 func (r *Reader) Reset(src io.Reader) error {
 	decoderStateInit(r)
 	r.src = src
-	r.buf = make([]byte, readBufSize)
+	if len(r.buf) > 0 {
+		for i := range r.buf {
+			r.buf[i] = 0
+		}
+	} else {
+		r.buf = make([]byte, readBufSize)
+	}
 	return nil
 }
 

--- a/reader.go
+++ b/reader.go
@@ -33,13 +33,10 @@ func NewReader(src io.Reader) *Reader {
 func (r *Reader) Reset(src io.Reader) error {
 	decoderStateInit(r)
 	r.src = src
-	if len(r.buf) > 0 {
-		for i := range r.buf {
-			r.buf[i] = 0
-		}
-	} else {
-		r.buf = make([]byte, readBufSize)
+	if r.buf != nil {
+		return nil
 	}
+	r.buf = make([]byte, readBufSize)
 	return nil
 }
 


### PR DESCRIPTION
When reusing brotli.Reader this change should reduce allocations.