### PR TITLE
Rest set writer.err=nil

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -61,6 +61,7 @@ func (w *Writer) Reset(dst io.Writer) {
 		w.params.lgwin = uint(w.options.LGWin)
 	}
 	w.dst = dst
+	w.err = nil
 }
 
 func (w *Writer) writeChunk(p []byte, op int) (n int, err error) {


### PR DESCRIPTION
Writer.Rest should set Writer.err = nil

When I reuse the Writer using sync.pool, the Writer may have an error due to the last communication and set Writer.err. Rest not set Writer.err = nil so Writer will return the last error to this communication.

In fact, once Writer.err is set, Writer.Reset() cannot be reused even if Writer.Reset() is called. So Write.Reset function should set Writer.err = nil