### PR TITLE
feat: upgrade Go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/andybalholm/brotli
 
-go 1.12
+go 1.18
 
 retract v1.0.1 // occasional panics and data corruption


### PR DESCRIPTION
Reason: 1.12 was released more than [3 years ago](https://go.dev/blog/go1.12), and since then, many changes/fixes were applied.

The project may benefit from these changes if we consider facts like security and performance.

<details>
<summary>Test execution using Go 1.18 - click to expand</summary>


Obs: tests running in a Docker image (`golang:1.18`):

```
docker run -ti --rm -v $(pwd):/code -w /code golang:1.18 sh
# go test -v --cover ./...
=== RUN   TestEncoderNoWrite
--- PASS: TestEncoderNoWrite (0.00s)
=== RUN   TestEncoderEmptyWrite
--- PASS: TestEncoderEmptyWrite (0.00s)
=== RUN   TestWriter
--- PASS: TestWriter (0.02s)
=== RUN   TestIssue22
--- PASS: TestIssue22 (6.89s)
=== RUN   TestEncoderStreams
--- PASS: TestEncoderStreams (0.13s)
=== RUN   TestEncoderLargeInput
--- PASS: TestEncoderLargeInput (2.46s)
=== RUN   TestEncoderFlush
--- PASS: TestEncoderFlush (0.00s)
=== RUN   TestDecoderStreaming
=== RUN   TestDecoderStreaming/Segment0
=== RUN   TestDecoderStreaming/Segment1
=== RUN   TestDecoderStreaming/Segment2
--- PASS: TestDecoderStreaming (0.00s)
    --- PASS: TestDecoderStreaming/Segment0 (0.00s)
    --- PASS: TestDecoderStreaming/Segment1 (0.00s)
    --- PASS: TestDecoderStreaming/Segment2 (0.00s)
=== RUN   TestReader
--- PASS: TestReader (0.00s)
=== RUN   TestDecode
--- PASS: TestDecode (0.00s)
=== RUN   TestQuality
--- PASS: TestQuality (0.08s)
=== RUN   TestDecodeFuzz
--- PASS: TestDecodeFuzz (0.00s)
=== RUN   TestDecodeTrailingData
--- PASS: TestDecodeTrailingData (0.00s)
=== RUN   TestEncodeDecode
    brotli_test.go:441: case "" x 0
    brotli_test.go:441: case "A" x 1
    brotli_test.go:441: case "<html><body><H1>Hello world</H1></body></html>" x 10
    brotli_test.go:441: case "<html><body><H1>Hello world</H1></body></html>" x 1000
--- PASS: TestEncodeDecode (0.00s)
=== RUN   ExampleWriter_Reset
--- PASS: ExampleWriter_Reset (0.00s)
PASS
coverage: 86.8% of statements
ok      github.com/andybalholm/brotli   9.587s  coverage: 86.8% of statements
# go version
go version go1.18.2 linux/amd64
```  

</details>