### PR TITLE
Add arm64 to GOARCH switches

### DIFF
--- a/find_match_length.go
+++ b/find_match_length.go
@@ -17,7 +17,7 @@ func findMatchLengthWithLimit(s1 []byte, s2 []byte, limit uint) uint {
 	var matched uint = 0
 	_, _ = s1[limit-1], s2[limit-1] // bounds check
 	switch runtime.GOARCH {
-	case "amd64":
+	case "amd64", "arm64":
 		// Compare 8 bytes at at time.
 		for matched+8 <= limit {
 			w1 := binary.LittleEndian.Uint64(s1[matched:])

--- a/matchfinder/m4.go
+++ b/matchfinder/m4.go
@@ -261,7 +261,7 @@ const hashMul64 = 0x1E35A7BD1E35A7BD
 //	0 <= i && i < j && j <= len(src)
 func extendMatch(src []byte, i, j int) int {
 	switch runtime.GOARCH {
-	case "amd64":
+	case "amd64", "arm64":
 		// As long as we are 8 or more bytes before the end of src, we can load and
 		// compare 8 bytes at a time. If those 8 bytes are equal, repeat.
 		for j+8 < len(src) {


### PR DESCRIPTION
BEFORE
---------

```
go test -bench BenchmarkEncodeLevelsReset
goos: darwin
goarch: arm64
pkg: github.com/andybalholm/brotli
cpu: Apple M4 Pro
BenchmarkEncodeLevelsReset/0-12              585           1976804 ns/op         286.93 MB/s             2.640 ratio          11 B/op          0 allocs/op
BenchmarkEncodeLevelsReset/1-12              430           2494767 ns/op         227.36 MB/s             2.948 ratio           4 B/op          0 allocs/op
BenchmarkEncodeLevelsReset/2-12              270           4396735 ns/op         129.00 MB/s             3.110 ratio          62 B/op          0 allocs/op
BenchmarkEncodeLevelsReset/3-12              230           5318254 ns/op         106.65 MB/s             3.148 ratio          10 B/op          0 allocs/op
BenchmarkEncodeLevelsReset/4-12              170           6987152 ns/op          81.18 MB/s             3.229 ratio        4651 B/op          0 allocs/op
BenchmarkEncodeLevelsReset/5-12              100          10760013 ns/op          52.71 MB/s             3.444 ratio          78 B/op          0 allocs/op
BenchmarkEncodeLevelsReset/6-12               93          12988458 ns/op          43.67 MB/s             3.519 ratio          62 B/op          0 allocs/op
BenchmarkEncodeLevelsReset/7-12               68          16704166 ns/op          33.96 MB/s             3.580 ratio       10430 B/op          0 allocs/op
BenchmarkEncodeLevelsReset/8-12               60          20312924 ns/op          27.92 MB/s             3.615 ratio       11642 B/op          0 allocs/op
BenchmarkEncodeLevelsReset/9-12               45          25868687 ns/op          21.93 MB/s             3.641 ratio         228 B/op          0 allocs/op
BenchmarkEncodeLevelsReset/10-12               4         265741656 ns/op           2.13 MB/s             3.903 ratio    20581992 B/op         76 allocs/op
BenchmarkEncodeLevelsReset/11-12               2         612110354 ns/op           0.93 MB/s             4.002 ratio    40716976 B/op         97 allocs/op
BenchmarkEncodeLevelsResetV2/0-12            464           2547521 ns/op         222.65 MB/s             2.675 ratio           3 B/op          0 allocs/op
BenchmarkEncodeLevelsResetV2/1-12            388           3035712 ns/op         186.84 MB/s             2.863 ratio          34 B/op          0 allocs/op
BenchmarkEncodeLevelsResetV2/2-12            247           4815694 ns/op         117.78 MB/s             3.343 ratio          92 B/op          0 allocs/op
BenchmarkEncodeLevelsResetV2/3-12            174           6862499 ns/op          82.65 MB/s             3.421 ratio         130 B/op          0 allocs/op
BenchmarkEncodeLevelsResetV2/4-12            156           7668163 ns/op          73.97 MB/s             3.453 ratio         145 B/op          0 allocs/op
BenchmarkEncodeLevelsResetV2/5-12            133           8978288 ns/op          63.17 MB/s             3.480 ratio          13 B/op          0 allocs/op
BenchmarkEncodeLevelsResetV2/6-12            100          11578452 ns/op          48.99 MB/s             3.518 ratio         227 B/op          0 allocs/op
BenchmarkEncodeLevelsResetV2/7-12             44          27181964 ns/op          20.87 MB/s             3.575 ratio         516 B/op          0 allocs/op
PASS
ok      github.com/andybalholm/brotli   35.355s
```

AFTER
---------
```
go test -bench BenchmarkEncodeLevelsReset
goos: darwin
goarch: arm64
pkg: github.com/andybalholm/brotli
cpu: Apple M4 Pro
BenchmarkEncodeLevelsReset/0-12              703           1683133 ns/op         336.99 MB/s             2.640 ratio           9 B/op          0 allocs/op
BenchmarkEncodeLevelsReset/1-12              498           2369475 ns/op         239.38 MB/s             2.948 ratio          10 B/op          0 allocs/op
BenchmarkEncodeLevelsReset/2-12              286           4148770 ns/op         136.71 MB/s             3.110 ratio          58 B/op          0 allocs/op
BenchmarkEncodeLevelsReset/3-12              247           4810287 ns/op         117.91 MB/s             3.148 ratio           8 B/op          0 allocs/op
BenchmarkEncodeLevelsReset/4-12              181           6622914 ns/op          85.64 MB/s             3.229 ratio        4369 B/op          0 allocs/op
BenchmarkEncodeLevelsReset/5-12              121           9807479 ns/op          57.83 MB/s             3.444 ratio        6329 B/op          0 allocs/op
BenchmarkEncodeLevelsReset/6-12              100          11930434 ns/op          47.54 MB/s             3.519 ratio        7313 B/op          0 allocs/op
BenchmarkEncodeLevelsReset/7-12               80          15413411 ns/op          36.80 MB/s             3.580 ratio        8869 B/op          0 allocs/op
BenchmarkEncodeLevelsReset/8-12               63          18672074 ns/op          30.38 MB/s             3.615 ratio       33091 B/op          0 allocs/op
BenchmarkEncodeLevelsReset/9-12               49          23775991 ns/op          23.86 MB/s             3.641 ratio       14359 B/op          0 allocs/op
BenchmarkEncodeLevelsReset/10-12               4         267663458 ns/op           2.12 MB/s             3.903 ratio    20581992 B/op         76 allocs/op
BenchmarkEncodeLevelsReset/11-12               2         601141416 ns/op           0.94 MB/s             4.002 ratio    40291152 B/op         83 allocs/op
BenchmarkEncodeLevelsResetV2/0-12            501           2357077 ns/op         240.64 MB/s             2.675 ratio          26 B/op          0 allocs/op
BenchmarkEncodeLevelsResetV2/1-12            422           2803867 ns/op         202.29 MB/s             2.863 ratio          31 B/op          0 allocs/op
BenchmarkEncodeLevelsResetV2/2-12            271           4393491 ns/op         129.10 MB/s             3.343 ratio          83 B/op          0 allocs/op
BenchmarkEncodeLevelsResetV2/3-12            194           6130906 ns/op          92.51 MB/s             3.421 ratio         117 B/op          0 allocs/op
BenchmarkEncodeLevelsResetV2/4-12            177           6757713 ns/op          83.93 MB/s             3.453 ratio         128 B/op          0 allocs/op
BenchmarkEncodeLevelsResetV2/5-12            153           7742243 ns/op          73.26 MB/s             3.480 ratio         148 B/op          0 allocs/op
BenchmarkEncodeLevelsResetV2/6-12            122           9913259 ns/op          57.22 MB/s             3.518 ratio         523 B/op          0 allocs/op
BenchmarkEncodeLevelsResetV2/7-12             51          23414704 ns/op          24.22 MB/s             3.575 ratio         445 B/op          0 allocs/op
PASS
ok      github.com/andybalholm/brotli   36.897s
```