### PR TITLE
Unnecessary nil checks have been removed.

### DIFF
--- a/metablock_command.go
+++ b/metablock_command.go
@@ -44,7 +44,10 @@ func initBlockSplitterCommand(self *blockSplitterCommand, alphabet_size uint, mi
 	brotli_ensure_capacity_uint32_t(&split.lengths, &split.lengths_alloc_size, max_num_blocks)
 	self.split_.num_blocks = max_num_blocks
 	*histograms_size = max_num_types
-	if histograms == nil || cap(*histograms) < int(*histograms_size) {
+	if histograms == nil {
+		histograms = new([]histogramCommand)
+	}
+	if cap(*histograms) < int(*histograms_size) {
 		*histograms = make([]histogramCommand, (*histograms_size))
 	} else {
 		*histograms = (*histograms)[:*histograms_size]
@@ -58,10 +61,13 @@ func initBlockSplitterCommand(self *blockSplitterCommand, alphabet_size uint, mi
 	self.last_histogram_ix_[0] = self.last_histogram_ix_[1]
 }
 
-/* Does either of three things:
-   (1) emits the current block with a new block type;
-   (2) emits the current block with the type of the second last block;
-   (3) merges the current block with the last block. */
+/*
+Does either of three things:
+
+	(1) emits the current block with a new block type;
+	(2) emits the current block with the type of the second last block;
+	(3) merges the current block with the last block.
+*/
 func blockSplitterFinishBlockCommand(self *blockSplitterCommand, is_final bool) {
 	var split *blockSplit = self.split_
 	var last_entropy []float64 = self.last_entropy_[:]
@@ -154,8 +160,11 @@ func blockSplitterFinishBlockCommand(self *blockSplitterCommand, is_final bool) 
 	}
 }
 
-/* Adds the next symbol to the current histogram. When the current histogram
-   reaches the target size, decides on merging the block. */
+/*
+Adds the next symbol to the current histogram. When the current histogram
+
+	reaches the target size, decides on merging the block.
+*/
 func blockSplitterAddSymbolCommand(self *blockSplitterCommand, symbol uint) {
 	histogramAddCommand(&self.histograms_[self.curr_histogram_ix_], symbol)
 	self.block_size_++

--- a/metablock_command.go
+++ b/metablock_command.go
@@ -44,9 +44,6 @@ func initBlockSplitterCommand(self *blockSplitterCommand, alphabet_size uint, mi
 	brotli_ensure_capacity_uint32_t(&split.lengths, &split.lengths_alloc_size, max_num_blocks)
 	self.split_.num_blocks = max_num_blocks
 	*histograms_size = max_num_types
-	if histograms == nil {
-		histograms = new([]histogramCommand)
-	}
 	if cap(*histograms) < int(*histograms_size) {
 		*histograms = make([]histogramCommand, (*histograms_size))
 	} else {

--- a/metablock_command.go
+++ b/metablock_command.go
@@ -58,12 +58,10 @@ func initBlockSplitterCommand(self *blockSplitterCommand, alphabet_size uint, mi
 	self.last_histogram_ix_[0] = self.last_histogram_ix_[1]
 }
 
-/*
-Does either of three things:
-
-	(1) emits the current block with a new block type;
-	(2) emits the current block with the type of the second last block;
-	(3) merges the current block with the last block.
+/* Does either of three things:
+   (1) emits the current block with a new block type;
+   (2) emits the current block with the type of the second last block;
+   (3) merges the current block with the last block.
 */
 func blockSplitterFinishBlockCommand(self *blockSplitterCommand, is_final bool) {
 	var split *blockSplit = self.split_

--- a/metablock_command.go
+++ b/metablock_command.go
@@ -61,8 +61,7 @@ func initBlockSplitterCommand(self *blockSplitterCommand, alphabet_size uint, mi
 /* Does either of three things:
    (1) emits the current block with a new block type;
    (2) emits the current block with the type of the second last block;
-   (3) merges the current block with the last block.
-*/
+   (3) merges the current block with the last block. */
 func blockSplitterFinishBlockCommand(self *blockSplitterCommand, is_final bool) {
 	var split *blockSplit = self.split_
 	var last_entropy []float64 = self.last_entropy_[:]
@@ -155,11 +154,8 @@ func blockSplitterFinishBlockCommand(self *blockSplitterCommand, is_final bool) 
 	}
 }
 
-/*
-Adds the next symbol to the current histogram. When the current histogram
-
-	reaches the target size, decides on merging the block.
-*/
+/* Adds the next symbol to the current histogram. When the current histogram
+   reaches the target size, decides on merging the block. */
 func blockSplitterAddSymbolCommand(self *blockSplitterCommand, symbol uint) {
 	histogramAddCommand(&self.histograms_[self.curr_histogram_ix_], symbol)
 	self.block_size_++

--- a/metablock_distance.go
+++ b/metablock_distance.go
@@ -44,7 +44,10 @@ func initBlockSplitterDistance(self *blockSplitterDistance, alphabet_size uint, 
 	brotli_ensure_capacity_uint32_t(&split.lengths, &split.lengths_alloc_size, max_num_blocks)
 	self.split_.num_blocks = max_num_blocks
 	*histograms_size = max_num_types
-	if histograms == nil || cap(*histograms) < int(*histograms_size) {
+	if histograms == nil {
+		histograms = new([]histogramDistance)
+	}
+	if cap(*histograms) < int(*histograms_size) {
 		*histograms = make([]histogramDistance, *histograms_size)
 	} else {
 		*histograms = (*histograms)[:*histograms_size]
@@ -58,10 +61,13 @@ func initBlockSplitterDistance(self *blockSplitterDistance, alphabet_size uint, 
 	self.last_histogram_ix_[0] = self.last_histogram_ix_[1]
 }
 
-/* Does either of three things:
-   (1) emits the current block with a new block type;
-   (2) emits the current block with the type of the second last block;
-   (3) merges the current block with the last block. */
+/*
+Does either of three things:
+
+	(1) emits the current block with a new block type;
+	(2) emits the current block with the type of the second last block;
+	(3) merges the current block with the last block.
+*/
 func blockSplitterFinishBlockDistance(self *blockSplitterDistance, is_final bool) {
 	var split *blockSplit = self.split_
 	var last_entropy []float64 = self.last_entropy_[:]
@@ -154,8 +160,11 @@ func blockSplitterFinishBlockDistance(self *blockSplitterDistance, is_final bool
 	}
 }
 
-/* Adds the next symbol to the current histogram. When the current histogram
-   reaches the target size, decides on merging the block. */
+/*
+Adds the next symbol to the current histogram. When the current histogram
+
+	reaches the target size, decides on merging the block.
+*/
 func blockSplitterAddSymbolDistance(self *blockSplitterDistance, symbol uint) {
 	histogramAddDistance(&self.histograms_[self.curr_histogram_ix_], symbol)
 	self.block_size_++

--- a/metablock_distance.go
+++ b/metablock_distance.go
@@ -61,8 +61,7 @@ func initBlockSplitterDistance(self *blockSplitterDistance, alphabet_size uint, 
 /* Does either of three things:
    (1) emits the current block with a new block type;
    (2) emits the current block with the type of the second last block;
-   (3) merges the current block with the last block.
-*/
+   (3) merges the current block with the last block. */
 func blockSplitterFinishBlockDistance(self *blockSplitterDistance, is_final bool) {
 	var split *blockSplit = self.split_
 	var last_entropy []float64 = self.last_entropy_[:]
@@ -155,11 +154,8 @@ func blockSplitterFinishBlockDistance(self *blockSplitterDistance, is_final bool
 	}
 }
 
-/*
-Adds the next symbol to the current histogram. When the current histogram
-
-	reaches the target size, decides on merging the block.
-*/
+/* Adds the next symbol to the current histogram. When the current histogram
+   reaches the target size, decides on merging the block. */
 func blockSplitterAddSymbolDistance(self *blockSplitterDistance, symbol uint) {
 	histogramAddDistance(&self.histograms_[self.curr_histogram_ix_], symbol)
 	self.block_size_++

--- a/metablock_distance.go
+++ b/metablock_distance.go
@@ -44,9 +44,6 @@ func initBlockSplitterDistance(self *blockSplitterDistance, alphabet_size uint, 
 	brotli_ensure_capacity_uint32_t(&split.lengths, &split.lengths_alloc_size, max_num_blocks)
 	self.split_.num_blocks = max_num_blocks
 	*histograms_size = max_num_types
-	if histograms == nil {
-		histograms = new([]histogramDistance)
-	}
 	if cap(*histograms) < int(*histograms_size) {
 		*histograms = make([]histogramDistance, *histograms_size)
 	} else {

--- a/metablock_distance.go
+++ b/metablock_distance.go
@@ -58,12 +58,10 @@ func initBlockSplitterDistance(self *blockSplitterDistance, alphabet_size uint, 
 	self.last_histogram_ix_[0] = self.last_histogram_ix_[1]
 }
 
-/*
-Does either of three things:
-
-	(1) emits the current block with a new block type;
-	(2) emits the current block with the type of the second last block;
-	(3) merges the current block with the last block.
+/* Does either of three things:
+   (1) emits the current block with a new block type;
+   (2) emits the current block with the type of the second last block;
+   (3) merges the current block with the last block.
 */
 func blockSplitterFinishBlockDistance(self *blockSplitterDistance, is_final bool) {
 	var split *blockSplit = self.split_

--- a/metablock_literal.go
+++ b/metablock_literal.go
@@ -44,9 +44,6 @@ func initBlockSplitterLiteral(self *blockSplitterLiteral, alphabet_size uint, mi
 	brotli_ensure_capacity_uint32_t(&split.lengths, &split.lengths_alloc_size, max_num_blocks)
 	self.split_.num_blocks = max_num_blocks
 	*histograms_size = max_num_types
-	if histograms == nil {
-		histograms = new([]histogramLiteral)
-	}
 	if cap(*histograms) < int(*histograms_size) {
 		*histograms = make([]histogramLiteral, *histograms_size)
 	} else {

--- a/metablock_literal.go
+++ b/metablock_literal.go
@@ -44,7 +44,10 @@ func initBlockSplitterLiteral(self *blockSplitterLiteral, alphabet_size uint, mi
 	brotli_ensure_capacity_uint32_t(&split.lengths, &split.lengths_alloc_size, max_num_blocks)
 	self.split_.num_blocks = max_num_blocks
 	*histograms_size = max_num_types
-	if histograms == nil || cap(*histograms) < int(*histograms_size) {
+	if histograms == nil {
+		histograms = new([]histogramLiteral)
+	}
+	if cap(*histograms) < int(*histograms_size) {
 		*histograms = make([]histogramLiteral, *histograms_size)
 	} else {
 		*histograms = (*histograms)[:*histograms_size]
@@ -58,10 +61,13 @@ func initBlockSplitterLiteral(self *blockSplitterLiteral, alphabet_size uint, mi
 	self.last_histogram_ix_[0] = self.last_histogram_ix_[1]
 }
 
-/* Does either of three things:
-   (1) emits the current block with a new block type;
-   (2) emits the current block with the type of the second last block;
-   (3) merges the current block with the last block. */
+/*
+Does either of three things:
+
+	(1) emits the current block with a new block type;
+	(2) emits the current block with the type of the second last block;
+	(3) merges the current block with the last block.
+*/
 func blockSplitterFinishBlockLiteral(self *blockSplitterLiteral, is_final bool) {
 	var split *blockSplit = self.split_
 	var last_entropy []float64 = self.last_entropy_[:]
@@ -154,8 +160,11 @@ func blockSplitterFinishBlockLiteral(self *blockSplitterLiteral, is_final bool) 
 	}
 }
 
-/* Adds the next symbol to the current histogram. When the current histogram
-   reaches the target size, decides on merging the block. */
+/*
+Adds the next symbol to the current histogram. When the current histogram
+
+	reaches the target size, decides on merging the block.
+*/
 func blockSplitterAddSymbolLiteral(self *blockSplitterLiteral, symbol uint) {
 	histogramAddLiteral(&self.histograms_[self.curr_histogram_ix_], symbol)
 	self.block_size_++

--- a/metablock_literal.go
+++ b/metablock_literal.go
@@ -58,12 +58,10 @@ func initBlockSplitterLiteral(self *blockSplitterLiteral, alphabet_size uint, mi
 	self.last_histogram_ix_[0] = self.last_histogram_ix_[1]
 }
 
-/*
-Does either of three things:
-
-	(1) emits the current block with a new block type;
-	(2) emits the current block with the type of the second last block;
-	(3) merges the current block with the last block.
+/* Does either of three things:
+   (1) emits the current block with a new block type;
+   (2) emits the current block with the type of the second last block;
+   (3) merges the current block with the last block.
 */
 func blockSplitterFinishBlockLiteral(self *blockSplitterLiteral, is_final bool) {
 	var split *blockSplit = self.split_

--- a/metablock_literal.go
+++ b/metablock_literal.go
@@ -61,8 +61,7 @@ func initBlockSplitterLiteral(self *blockSplitterLiteral, alphabet_size uint, mi
 /* Does either of three things:
    (1) emits the current block with a new block type;
    (2) emits the current block with the type of the second last block;
-   (3) merges the current block with the last block.
-*/
+   (3) merges the current block with the last block. */
 func blockSplitterFinishBlockLiteral(self *blockSplitterLiteral, is_final bool) {
 	var split *blockSplit = self.split_
 	var last_entropy []float64 = self.last_entropy_[:]
@@ -155,11 +154,8 @@ func blockSplitterFinishBlockLiteral(self *blockSplitterLiteral, is_final bool) 
 	}
 }
 
-/*
-Adds the next symbol to the current histogram. When the current histogram
-
-	reaches the target size, decides on merging the block.
-*/
+/* Adds the next symbol to the current histogram. When the current histogram
+   reaches the target size, decides on merging the block. */
 func blockSplitterAddSymbolLiteral(self *blockSplitterLiteral, symbol uint) {
 	histogramAddLiteral(&self.histograms_[self.curr_histogram_ix_], symbol)
 	self.block_size_++


### PR DESCRIPTION
Three critical vulnerabilities leading to null pointer dereference have been fixed in this request.

1. After having been compared to a nil value at metablock_command.go:47, pointer 'histograms' is dereferenced at metablock_command.go:48.
2. After having been compared to a nil value at metablock_distance.go:47, pointer 'histograms' is dereferenced at metablock_distance.go:48.
3. After having been compared to a nil value at metablock_literal.go:47, pointer 'histograms' is dereferenced at metablock_literal.go:48.