### PR TITLE
matchfinder: verify candidate matches against source data

### DIFF
--- a/brotli_test.go
+++ b/brotli_test.go
@@ -1012,3 +1012,28 @@ func TestIssue58(t *testing.T) {
 		t.Fatalf("expected error, got none and read:\n%x\n%s\n%v", buf, buf, buf)
 	}
 }
+
+func TestV2FalseMatchZeroVal(t *testing.T) {
+	// Minimal reproducer: 7 non-zero bytes followed by 7 zero bytes.
+	// The zero bytes hash to a bucket with an uninitialized entry (val=0),
+	// causing a false match that corrupts the output.
+	data := []byte{
+		0x0a, 0x0c, 0x0e, 0x15, 0x1c, 0x23, 0x2a,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	}
+
+	for level := 0; level <= 9; level++ {
+		var buf bytes.Buffer
+		w := NewWriterV2(&buf, level)
+		w.Write(data)
+		w.Close()
+
+		decompressed, err := io.ReadAll(NewReader(bytes.NewReader(buf.Bytes())))
+		if err != nil {
+			t.Fatalf("level %d: decompress error: %v", level, err)
+		}
+		if !bytes.Equal(data, decompressed) {
+			t.Fatalf("level %d: decompressed data doesn't match", level)
+		}
+	}
+}

--- a/matchfinder/bargain1.go
+++ b/matchfinder/bargain1.go
@@ -163,7 +163,8 @@ func (z *Bargain1) FindMatches(dst []Match, src []byte) []Match {
 		nextByteIsUnmatched := arrivals[i-historyLen-1+1].distance == 0
 
 		if unmatched > 0 || i >= nextOverlapSearch || nextByteIsUnmatched {
-			if int(candidate6.offset) < i && i-int(candidate6.offset) < z.MaxDistance && uint32(cv) == candidate6.val {
+			if int(candidate6.offset) < i && i-int(candidate6.offset) < z.MaxDistance && uint32(cv) == candidate6.val &&
+				binary.LittleEndian.Uint32(src[candidate6.offset:]) == uint32(cv) {
 				m := extendMatch2(src, i, int(candidate6.offset), historyLen)
 				delta := i - m.Start
 				if delta == 0 {

--- a/matchfinder/bargain2.go
+++ b/matchfinder/bargain2.go
@@ -179,7 +179,8 @@ func (z *Bargain2) FindMatches(dst []Match, src []byte) []Match {
 		nextByteIsUnmatched := arrivals[i-historyLen-1+1].distance == 0
 
 		if unmatched > 0 || i >= nextOverlapSearch || nextByteIsUnmatched {
-			if int(candidate5.offset) < i && i-int(candidate5.offset) < z.MaxDistance && uint32(cv) == candidate5.val {
+			if int(candidate5.offset) < i && i-int(candidate5.offset) < z.MaxDistance && uint32(cv) == candidate5.val &&
+				binary.LittleEndian.Uint32(src[candidate5.offset:]) == uint32(cv) {
 				m := extendMatch2(src, i, int(candidate5.offset), historyLen)
 				delta := i - m.Start
 				if delta == 0 {
@@ -194,7 +195,8 @@ func (z *Bargain2) FindMatches(dst []Match, src []byte) []Match {
 				nextOverlapSearch = max(nextOverlapSearch, m.Start+1, m.End-6)
 			}
 
-			if int(candidate8.offset) < i && i-int(candidate8.offset) < z.MaxDistance && uint32(cv) == candidate8.val {
+			if int(candidate8.offset) < i && i-int(candidate8.offset) < z.MaxDistance && uint32(cv) == candidate8.val &&
+				binary.LittleEndian.Uint32(src[candidate8.offset:]) == uint32(cv) {
 				m := extendMatch2(src, i, int(candidate8.offset), historyLen)
 				delta := i - m.Start
 				if delta == 0 {

--- a/matchfinder/bargain3.go
+++ b/matchfinder/bargain3.go
@@ -189,7 +189,8 @@ func (z *Bargain3) FindMatches(dst []Match, src []byte) []Match {
 		nextByteIsUnmatched := arrivals[i-historyLen-1+1].distance == 0
 
 		if unmatched > 0 || i >= nextOverlapSearch || nextByteIsUnmatched {
-			if int(candidate5.offset) < i && i-int(candidate5.offset) < z.MaxDistance && uint32(cv) == candidate5.val {
+			if int(candidate5.offset) < i && i-int(candidate5.offset) < z.MaxDistance && uint32(cv) == candidate5.val &&
+				binary.LittleEndian.Uint32(src[candidate5.offset:]) == uint32(cv) {
 				m := extendMatch2(src, i, int(candidate5.offset), historyLen)
 				delta := i - m.Start
 				if delta == 0 {
@@ -204,7 +205,8 @@ func (z *Bargain3) FindMatches(dst []Match, src []byte) []Match {
 				nextOverlapSearch = max(nextOverlapSearch, m.Start+1, m.End-6)
 			}
 
-			if int(candidate8.offset) < i && i-int(candidate8.offset) < z.MaxDistance && uint32(cv) == candidate8.val {
+			if int(candidate8.offset) < i && i-int(candidate8.offset) < z.MaxDistance && uint32(cv) == candidate8.val &&
+				binary.LittleEndian.Uint32(src[candidate8.offset:]) == uint32(cv) {
 				m := extendMatch2(src, i, int(candidate8.offset), historyLen)
 				delta := i - m.Start
 				if delta == 0 {
@@ -219,7 +221,8 @@ func (z *Bargain3) FindMatches(dst []Match, src []byte) []Match {
 				nextOverlapSearch = max(nextOverlapSearch, m.Start+1, m.End-6)
 			}
 
-			if int(candidate12.offset) < i && i-int(candidate12.offset) < z.MaxDistance && uint32(cv) == candidate12.val {
+			if int(candidate12.offset) < i && i-int(candidate12.offset) < z.MaxDistance && uint32(cv) == candidate12.val &&
+				binary.LittleEndian.Uint32(src[candidate12.offset:]) == uint32(cv) {
 				m := extendMatch2(src, i, int(candidate12.offset), historyLen)
 				delta := i - m.Start
 				if delta == 0 {

--- a/matchfinder/trio.go
+++ b/matchfinder/trio.go
@@ -119,18 +119,21 @@ mainLoop:
 				}
 			}
 
-			if candidate12.offset < s && s-candidate12.offset < int32(z.MaxDistance) && uint32(cv) == candidate12.val {
+			if candidate12.offset < s && s-candidate12.offset < int32(z.MaxDistance) && uint32(cv) == candidate12.val &&
+				binary.LittleEndian.Uint32(src[candidate12.offset:]) == uint32(cv) {
 				// There is a 12-byte match at s.
 				t = candidate12.offset
 				hashLengthFound = 12
 				break
 			}
-			if candidate8.offset < s && s-candidate8.offset < int32(z.MaxDistance) && uint32(cv) == candidate8.val {
+			if candidate8.offset < s && s-candidate8.offset < int32(z.MaxDistance) && uint32(cv) == candidate8.val &&
+				binary.LittleEndian.Uint32(src[candidate8.offset:]) == uint32(cv) {
 				t = candidate8.offset
 				hashLengthFound = 8
 				break
 			}
-			if candidate5.offset < s && s-candidate5.offset < int32(z.MaxDistance) && uint32(cv) == candidate5.val {
+			if candidate5.offset < s && s-candidate5.offset < int32(z.MaxDistance) && uint32(cv) == candidate5.val &&
+				binary.LittleEndian.Uint32(src[candidate5.offset:]) == uint32(cv) {
 				t = candidate5.offset
 				hashLengthFound = 5
 				break
@@ -157,10 +160,12 @@ mainLoop:
 			entry := tableEntry{offset: s + 1, val: uint32(cv)}
 			z.table12[nextHash12] = entry
 			z.table8[nextHash8] = entry
-			if candidate12.offset < s+1 && coffset12 < int32(z.MaxDistance) && uint32(cv) == candidate12.val {
+			if candidate12.offset < s+1 && coffset12 < int32(z.MaxDistance) && uint32(cv) == candidate12.val &&
+				binary.LittleEndian.Uint32(src[candidate12.offset:]) == uint32(cv) {
 				t = candidate12.offset
 				s++
-			} else if hashLengthFound < 8 && candidate8.offset < s+1 && coffset8 < int32(z.MaxDistance) && uint32(cv) == candidate8.val {
+			} else if hashLengthFound < 8 && candidate8.offset < s+1 && coffset8 < int32(z.MaxDistance) && uint32(cv) == candidate8.val &&
+				binary.LittleEndian.Uint32(src[candidate8.offset:]) == uint32(cv) {
 				t = candidate8.offset
 				s++
 			}
@@ -206,10 +211,12 @@ mainLoop:
 			z.table5[nextHash5] = entry
 
 			t = -1
-			if candidate12.offset < s && s-candidate12.offset < int32(z.MaxDistance) && uint32(cv) == candidate12.val {
+			if candidate12.offset < s && s-candidate12.offset < int32(z.MaxDistance) && uint32(cv) == candidate12.val &&
+				binary.LittleEndian.Uint32(src[candidate12.offset:]) == uint32(cv) {
 				// There is a 12-byte match at s.
 				t = candidate12.offset
-			} else if candidate8.offset < s && s-candidate8.offset < int32(z.MaxDistance) && uint32(cv) == candidate8.val {
+			} else if candidate8.offset < s && s-candidate8.offset < int32(z.MaxDistance) && uint32(cv) == candidate8.val &&
+				binary.LittleEndian.Uint32(src[candidate8.offset:]) == uint32(cv) {
 				// There is a long match at s.
 				t = candidate8.offset
 			}

--- a/matchfinder/zdfast.go
+++ b/matchfinder/zdfast.go
@@ -133,11 +133,17 @@ mainLoop:
 			coffsetL := s - (candidateL.offset - z.current)
 			coffsetS := s - (candidateS.offset - z.current)
 			if coffsetL < int32(z.MaxDistance) && uint32(cv) == candidateL.val {
-				// found a long match (likely at least 8 bytes)
 				t = candidateL.offset - z.current
-				break
+				if binary.LittleEndian.Uint32(src[t:]) == uint32(cv) {
+					// found a long match (likely at least 8 bytes)
+					break
+				}
 			}
 			if coffsetS < int32(z.MaxDistance) && uint32(cv) == candidateS.val {
+				t = candidateS.offset - z.current
+				if binary.LittleEndian.Uint32(src[t:]) != uint32(cv) {
+					goto noMatch
+				}
 				// Found a regular match.
 				// See if we can find a long match at s+1
 				cv := binary.LittleEndian.Uint64(src[s+1:])
@@ -146,16 +152,19 @@ mainLoop:
 				coffsetL = s - (candidateL.offset - z.current) + 1
 				z.longTable[nextHashL] = tableEntry{offset: s + 1 + z.current, val: uint32(cv)}
 				if coffsetL < int32(z.MaxDistance) && uint32(cv) == candidateL.val {
-					// We found a long match at s+1, so we'll use that instead
-					// of the regular match at s.
 					t = candidateL.offset - z.current
-					s++
-					break
+					if binary.LittleEndian.Uint32(src[t:]) == uint32(cv) {
+						// We found a long match at s+1, so we'll use that instead
+						// of the regular match at s.
+						s++
+						break
+					}
 				}
 
 				t = candidateS.offset - z.current
 				break
 			}
+		noMatch:
 
 			s += stepSize + ((s - nextEmit) >> 7)
 			if s > sLimit {

--- a/matchfinder/zfast.go
+++ b/matchfinder/zfast.go
@@ -127,14 +127,18 @@ mainLoop:
 			coffset0 := s - (candidate.offset - z.current)
 			coffset1 := s - (candidate2.offset - z.current) + 1
 			if coffset0 < int32(z.MaxDistance) && uint32(cv) == candidate.val {
-				// found a regular match
 				t = candidate.offset - z.current
-				break
+				if binary.LittleEndian.Uint32(src[t:]) == uint32(cv) {
+					// found a regular match
+					break
+				}
 			}
 			if coffset1 < int32(z.MaxDistance) && uint32(cv>>8) == candidate2.val {
 				t = candidate2.offset - z.current
-				s++
-				break
+				if binary.LittleEndian.Uint32(src[t:]) == uint32(cv>>8) {
+					s++
+					break
+				}
 			}
 
 			s += stepSize + ((s - nextEmit) >> 5)

--- a/matchfinder/zm.go
+++ b/matchfinder/zm.go
@@ -110,12 +110,14 @@ mainLoop:
 				}
 			}
 
-			if candidateL.offset < s && s-candidateL.offset < int32(z.MaxDistance) && uint32(cv) == candidateL.val {
+			if candidateL.offset < s && s-candidateL.offset < int32(z.MaxDistance) && uint32(cv) == candidateL.val &&
+				binary.LittleEndian.Uint32(src[candidateL.offset:]) == uint32(cv) {
 				// There is a long match at s.
 				t = candidateL.offset
 				break
 			}
-			if candidateS.offset < s && s-candidateS.offset < int32(z.MaxDistance) && uint32(cv) == candidateS.val {
+			if candidateS.offset < s && s-candidateS.offset < int32(z.MaxDistance) && uint32(cv) == candidateS.val &&
+				binary.LittleEndian.Uint32(src[candidateS.offset:]) == uint32(cv) {
 				// There is a regular match at s.
 				// See if we can find a long match at s+1.
 				cv := binary.LittleEndian.Uint64(src[s+1:])
@@ -123,7 +125,8 @@ mainLoop:
 				candidateL = z.longTable[nextHashL]
 				coffsetL := s - candidateL.offset + 1
 				z.longTable[nextHashL] = tableEntry{offset: s + 1, val: uint32(cv)}
-				if candidateL.offset < s+1 && coffsetL < int32(z.MaxDistance) && uint32(cv) == candidateL.val {
+				if candidateL.offset < s+1 && coffsetL < int32(z.MaxDistance) && uint32(cv) == candidateL.val &&
+					binary.LittleEndian.Uint32(src[candidateL.offset:]) == uint32(cv) {
 					// We found a long match at s+1, so we'll use that instead
 					// of the regular match at s.
 					t = candidateL.offset
@@ -175,10 +178,12 @@ mainLoop:
 			z.table[nextHashS] = entry
 
 			t = -1
-			if candidateL.offset < s && s-candidateL.offset < int32(z.MaxDistance) && uint32(cv) == candidateL.val {
+			if candidateL.offset < s && s-candidateL.offset < int32(z.MaxDistance) && uint32(cv) == candidateL.val &&
+				binary.LittleEndian.Uint32(src[candidateL.offset:]) == uint32(cv) {
 				// There is a long match at s.
 				t = candidateL.offset
-			} else if candidateS.offset < s && s-candidateS.offset < int32(z.MaxDistance) && uint32(cv) == candidateS.val {
+			} else if candidateS.offset < s && s-candidateS.offset < int32(z.MaxDistance) && uint32(cv) == candidateS.val &&
+				binary.LittleEndian.Uint32(src[candidateS.offset:]) == uint32(cv) {
 				// There is a regular match at s.
 				t = candidateS.offset
 				// See if we can find a long match at s+1.
@@ -187,7 +192,8 @@ mainLoop:
 				candidateL = z.longTable[nextHashL]
 				coffsetL := s - candidateL.offset + 1
 				z.longTable[nextHashL] = tableEntry{offset: s + 1, val: uint32(cv)}
-				if candidateL.offset < s+1 && coffsetL < int32(z.MaxDistance) && uint32(cv) == candidateL.val {
+				if candidateL.offset < s+1 && coffsetL < int32(z.MaxDistance) && uint32(cv) == candidateL.val &&
+					binary.LittleEndian.Uint32(src[candidateL.offset:]) == uint32(cv) {
 					// We found a long match at s+1, so we'll use that instead
 					// of the regular match at s.
 					t = candidateL.offset


### PR DESCRIPTION
All V2 matchfinders use hash tables with zero-initialized tableEntry structs (val=0, offset=0). The match validation relies solely on comparing the cached val field against the current position bytes.

When input data contains four or more consecutive zero bytes, the check uint32(cv) == candidate.val succeeds against uninitialized table entries because both sides are zero. The matchfinder then reports a match at the uninitialized offset, which points to position 0 containing completely unrelated data. This produces silent data corruption on round-trip compression/decompression.

Add source data verification after every cached val comparison across all seven matchfinders (ZFast, ZDFast, ZM, Trio, Bargain1, Bargain2, Bargain3). After the val check passes, read the actual bytes from the source buffer at the candidate offset and confirm they match. This catches both the zero-initialization false positives and any theoretical hash collision where two different positions store the same val through a hash bucket collision.

The additional uint32 read on the match path has negligible performance impact since the source data is typically already in cache from nearby accesses.


Consider this reproducer:

```go
package brotli

import (
        "bytes"
        "io"
        "testing"
)

// TestV2FalseMatchZeroVal reproduces a data corruption bug in V2 matchfinders.
//
// Minimal reproducer: 7 non-zero bytes followed by 7 zero bytes (14 bytes
// total). At position 7, ZFast hashes the zero bytes, finds an uninitialized
// table entry with val=0, declares a match at distance 7 (from position 0),
// and copies 4 bytes of wrong data.
func TestV2FalseMatchZeroVal(t *testing.T) {
        data := []byte{
                0x0a, 0x0c, 0x0e, 0x15, 0x1c, 0x23, 0x2a,
                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
        }

        for level := 0; level <= 9; level++ {
                var compressed bytes.Buffer
                w := NewWriterV2(&compressed, level)
                w.Write(data)
                w.Close()

                decompressed, err := io.ReadAll(NewReader(bytes.NewReader(compressed.Bytes())))
                if err != nil {
                        t.Fatalf("level %d: decompress error: %v", level, err)
                }

                if !bytes.Equal(data, decompressed) {
                        for i := range data {
                                if i < len(decompressed) && data[i] != decompressed[i] {
                                        t.Errorf("level %d: corruption at byte %d: want 0x%02x got 0x%02x",
                                                level, i, data[i], decompressed[i])
                                        break
                                }
                        }
                }
        }
}
```