### PR TITLE
matchfinder: optimize buffer and chain reuse

### DIFF
--- a/matchfinder/grow.go
+++ b/matchfinder/grow.go
@@ -1,0 +1,15 @@
+package matchfinder
+
+import "slices"
+
+func growClearUint32(dst []uint32, n int) []uint32 {
+	if n <= 0 {
+		return dst
+	}
+
+	oldLen := len(dst)
+	dst = slices.Grow(dst, n)
+	dst = dst[:oldLen+n]
+	clear(dst[oldLen:])
+	return dst
+}

--- a/matchfinder/m4.go
+++ b/matchfinder/m4.go
@@ -102,7 +102,7 @@ func (q *M4) FindMatches(dst []Match, src []byte) []Match {
 	e.NextEmit = len(q.history)
 	q.history = append(q.history, src...)
 	if q.ChainLength > 0 {
-		q.chain = append(q.chain, make([]uint32, len(src))...)
+		q.chain = growClearUint32(q.chain, len(src))
 	}
 	src = q.history
 

--- a/matchfinder/matchfinder.go
+++ b/matchfinder/matchfinder.go
@@ -52,6 +52,7 @@ type Writer struct {
 
 	err     error
 	inBuf   []byte
+	inStart int
 	outBuf  []byte
 	matches []Match
 }
@@ -65,14 +66,20 @@ func (w *Writer) Write(p []byte) (n int, err error) {
 		return w.writeBlock(p, false)
 	}
 
-	w.inBuf = append(w.inBuf, p...)
-	var pos int
-	for pos = 0; pos+w.BlockSize <= len(w.inBuf) && w.err == nil; pos += w.BlockSize {
-		w.writeBlock(w.inBuf[pos:pos+w.BlockSize], false)
-	}
-	if pos > 0 {
-		n := copy(w.inBuf, w.inBuf[pos:])
+	if w.inStart > 0 && len(w.inBuf)+len(p) > cap(w.inBuf) {
+		n := copy(w.inBuf, w.inBuf[w.inStart:])
 		w.inBuf = w.inBuf[:n]
+		w.inStart = 0
+	}
+
+	w.inBuf = append(w.inBuf, p...)
+	for w.inStart+w.BlockSize <= len(w.inBuf) && w.err == nil {
+		w.writeBlock(w.inBuf[w.inStart:w.inStart+w.BlockSize], false)
+		w.inStart += w.BlockSize
+	}
+	if w.inStart == len(w.inBuf) {
+		w.inBuf = w.inBuf[:0]
+		w.inStart = 0
 	}
 
 	return len(p), w.err
@@ -87,8 +94,9 @@ func (w *Writer) writeBlock(p []byte, lastBlock bool) (n int, err error) {
 }
 
 func (w *Writer) Close() error {
-	w.writeBlock(w.inBuf, true)
+	w.writeBlock(w.inBuf[w.inStart:], true)
 	w.inBuf = w.inBuf[:0]
+	w.inStart = 0
 	return w.err
 }
 
@@ -97,6 +105,7 @@ func (w *Writer) Reset(newDest io.Writer) {
 	w.Encoder.Reset()
 	w.err = nil
 	w.inBuf = w.inBuf[:0]
+	w.inStart = 0
 	w.outBuf = w.outBuf[:0]
 	w.matches = w.matches[:0]
 	w.Dest = newDest

--- a/matchfinder/pathfinder.go
+++ b/matchfinder/pathfinder.go
@@ -120,7 +120,7 @@ func (q *Pathfinder) FindMatches(dst []Match, src []byte) []Match {
 	// Append src to the history buffer.
 	historyLen := len(q.history)
 	q.history = append(q.history, src...)
-	q.chain = append(q.chain, make([]uint32, len(src))...)
+	q.chain = growClearUint32(q.chain, len(src))
 	src = q.history
 
 	// Calculate hashes and build the chain.


### PR DESCRIPTION
Avoid compacting matchfinder.Writer's input buffer after every processed block. Keep a start offset and only compact when append would otherwise run out of capacity.

Also grow Pathfinder and M4 chain buffers in place instead of append(..., make(... )...), which was previously zeroing and copying an intermediate slice for each block.

Local benchmark results:
- BenchmarkEncodeLevelsResetV2/4: 88.34 -> 89.44 MB/s
- BenchmarkEncodeM4: 62.71 -> 73.11 MB/s
- BenchmarkEncodeM4Chain256: 6.86 -> 10.54 MB/s
- BenchmarkEncodePathfinder: 25.40 -> 36.26 MB/s
- BenchmarkEncodePathfinderChain256: 2.13 -> 5.07 MB/s

This is faster because it removes avoidable memory traffic: the writer no longer memmoves buffered tails on each block boundary, and the chain-based matchfinders no longer build a temporary zero-filled slice before appending.