### PR TITLE
Reuse huffman codes buffers

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -2365,17 +2365,9 @@ func decoderDecompressStream(s *Reader, available_in *uint, next_in *[]byte, ava
 					break
 				}
 
-				if !decoderHuffmanTreeGroupInit(s, &s.literal_hgroup, numLiteralSymbols, numLiteralSymbols, s.num_literal_htrees) {
-					allocation_success = false
-				}
-
-				if !decoderHuffmanTreeGroupInit(s, &s.insert_copy_hgroup, numCommandSymbols, numCommandSymbols, s.num_block_types[1]) {
-					allocation_success = false
-				}
-
-				if !decoderHuffmanTreeGroupInit(s, &s.distance_hgroup, num_distance_codes, max_distance_symbol, s.num_dist_htrees) {
-					allocation_success = false
-				}
+				decoderHuffmanTreeGroupInit(&s.literal_hgroup, numLiteralSymbols, numLiteralSymbols, s.num_literal_htrees)
+				decoderHuffmanTreeGroupInit(&s.insert_copy_hgroup, numCommandSymbols, numCommandSymbols, s.num_block_types[1])
+				decoderHuffmanTreeGroupInit(&s.distance_hgroup, num_distance_codes, max_distance_symbol, s.num_dist_htrees)
 
 				if !allocation_success {
 					return saveErrorCode(s, decoderErrorAllocTreeGroups)

--- a/decode.go
+++ b/decode.go
@@ -2175,12 +2175,9 @@ func decoderDecompressStream(s *Reader, available_in *uint, next_in *[]byte, ava
 		case stateInitialize:
 			s.max_backward_distance = (1 << s.window_bits) - windowGap
 
-			/* Allocate memory for both block_type_trees and block_len_trees. */
-			s.block_type_trees = make([]huffmanCode, (3 * (huffmanMaxSize258 + huffmanMaxSize26)))
-
 			if s.block_type_trees == nil {
-				result = decoderErrorAllocBlockTypeTrees
-				break
+				/* Allocate memory for both block_type_trees and block_len_trees. */
+				s.block_type_trees = make([]huffmanCode, (3 * (huffmanMaxSize258 + huffmanMaxSize26)))
 			}
 
 			s.block_len_trees = s.block_type_trees[3*huffmanMaxSize258:]

--- a/reader.go
+++ b/reader.go
@@ -34,7 +34,10 @@ func (r *Reader) Reset(src io.Reader) error {
 	if r.error_code < 0 {
 		// There was an unrecoverable error, leaving the Reader's state
 		// undefined. Clear out everything but the buffer.
-		*r = Reader{buf: r.buf}
+		*r = Reader{
+			buf:              r.buf,
+			block_type_trees: r.block_type_trees,
+		}
 	}
 
 	decoderStateInit(r)

--- a/reader.go
+++ b/reader.go
@@ -33,10 +33,22 @@ func NewReader(src io.Reader) *Reader {
 func (r *Reader) Reset(src io.Reader) error {
 	if r.error_code < 0 {
 		// There was an unrecoverable error, leaving the Reader's state
-		// undefined. Clear out everything but the buffer.
+		// undefined. Clear out everything but the buffers.
 		*r = Reader{
 			buf:              r.buf,
 			block_type_trees: r.block_type_trees,
+			literal_hgroup: huffmanTreeGroup{
+				htrees: r.literal_hgroup.htrees,
+				codes:  r.literal_hgroup.codes,
+			},
+			distance_hgroup: huffmanTreeGroup{
+				htrees: r.distance_hgroup.htrees,
+				codes:  r.distance_hgroup.codes,
+			},
+			insert_copy_hgroup: huffmanTreeGroup{
+				htrees: r.insert_copy_hgroup.htrees,
+				codes:  r.insert_copy_hgroup.codes,
+			},
 		}
 	}
 

--- a/state.go
+++ b/state.go
@@ -212,12 +212,8 @@ func decoderStateInit(s *Reader) bool {
 
 	s.sub_loop_counter = 0
 
-	s.literal_hgroup.codes = nil
-	s.literal_hgroup.htrees = nil
-	s.insert_copy_hgroup.codes = nil
-	s.insert_copy_hgroup.htrees = nil
-	s.distance_hgroup.codes = nil
-	s.distance_hgroup.htrees = nil
+	cleanupCodes(s)
+	cleanupHTrees(s)
 
 	s.is_last_metablock = 0
 	s.is_uncompressed = 0
@@ -232,8 +228,6 @@ func decoderStateInit(s *Reader) bool {
 	s.dist_rb[2] = 11
 	s.dist_rb[3] = 4
 	s.dist_rb_idx = 0
-	clear(s.block_type_trees)
-	s.block_len_trees = nil
 
 	s.symbol_lists.storage = s.symbols_lists_array[:]
 	s.symbol_lists.offset = huffmanMaxCodeLength + 1
@@ -266,29 +260,54 @@ func decoderStateMetablockBegin(s *Reader) {
 	s.dist_context_map_slice = nil
 	s.dist_htree_index = 0
 	s.context_lookup = nil
-	s.literal_hgroup.codes = nil
-	s.literal_hgroup.htrees = nil
-	s.insert_copy_hgroup.codes = nil
-	s.insert_copy_hgroup.htrees = nil
-	s.distance_hgroup.codes = nil
-	s.distance_hgroup.htrees = nil
+
+	cleanupCodes(s)
+	cleanupHTrees(s)
 }
 
 func decoderStateCleanupAfterMetablock(s *Reader) {
 	s.context_modes = nil
 	s.context_map = nil
 	s.dist_context_map = nil
-	s.literal_hgroup.htrees = nil
-	s.insert_copy_hgroup.htrees = nil
-	s.distance_hgroup.htrees = nil
+	cleanupHTrees(s)
 }
 
-func decoderHuffmanTreeGroupInit(s *Reader, group *huffmanTreeGroup, alphabet_size uint32, max_symbol uint32, ntrees uint32) bool {
+func decoderHuffmanTreeGroupInit(group *huffmanTreeGroup, alphabet_size uint32, max_symbol uint32, ntrees uint32) {
 	var max_table_size uint = uint(kMaxHuffmanTableSize[(alphabet_size+31)>>5])
 	group.alphabet_size = uint16(alphabet_size)
 	group.max_symbol = uint16(max_symbol)
 	group.num_htrees = uint16(ntrees)
-	group.htrees = make([][]huffmanCode, ntrees)
-	group.codes = make([]huffmanCode, (uint(ntrees) * max_table_size))
-	return !(group.codes == nil)
+
+	makeCodesBuffer(group, uint(ntrees)*max_table_size)
+	makeTreesBuffer(group, ntrees)
+}
+
+func makeTreesBuffer(group *huffmanTreeGroup, treesLen uint32) {
+	if cap(group.htrees) < int(treesLen) {
+		group.htrees = make([][]huffmanCode, treesLen)
+		return
+	}
+
+	group.htrees = group.htrees[:treesLen]
+}
+
+func makeCodesBuffer(group *huffmanTreeGroup, codesLen uint) {
+	if cap(group.codes) < int(codesLen) {
+		group.codes = make([]huffmanCode, codesLen)
+		return
+	}
+
+	group.codes = group.codes[:codesLen]
+}
+
+func cleanupCodes(s *Reader) {
+	clear(s.literal_hgroup.codes)
+	clear(s.insert_copy_hgroup.codes)
+	clear(s.distance_hgroup.codes)
+}
+
+func cleanupHTrees(s *Reader) {
+	clear(s.literal_hgroup.htrees)
+	clear(s.insert_copy_hgroup.htrees)
+	clear(s.distance_hgroup.htrees)
 }

--- a/state.go
+++ b/state.go
@@ -198,7 +198,7 @@ func decoderStateInit(s *Reader) bool {
 	s.rb_roundtrips = 0
 	s.partial_pos_out = 0
 
-	s.block_type_trees = nil
+	clear(s.block_type_trees)
 	s.block_len_trees = nil
 	s.ringbuffer_size = 0
 	s.new_ringbuffer_size = 0
@@ -232,7 +232,7 @@ func decoderStateInit(s *Reader) bool {
 	s.dist_rb[2] = 11
 	s.dist_rb[3] = 4
 	s.dist_rb_idx = 0
-	s.block_type_trees = nil
+	clear(s.block_type_trees)
 	s.block_len_trees = nil
 
 	s.symbol_lists.storage = s.symbols_lists_array[:]


### PR DESCRIPTION
I am using the fasthttp Client to retrieve data compressed with brotli. I discovered large allocations in the profile.

The benchmark results of the existing fasthttp decompressing functions looked depressing.
```
func Benchmark_Decompress(b *testing.B) {
	const body = `{"id": 101,"username": "J_Smith","email": "J_Smith@example.com","isActive": true,"roles":` +
		`["admin", "user"],"profile": {"firstName": "John","lastName": "Smith","age": 30},"lastLogin": null}`

	var (
		bBrotli      = bytes.NewBuffer(nil)
		bDeflate     = bytes.NewBuffer(nil)
		bGzip        = bytes.NewBuffer(nil)
		decompressed = bytes.NewBuffer(nil)
	)
	WriteBrotli(bBrotli, []byte(body))
	WriteDeflate(bDeflate, []byte(body))
	WriteGzip(bGzip, []byte(body))

	decompressed.Grow(1024)

	b.Run("deflate", func(b *testing.B) {
		for b.Loop() {
			WriteInflate(decompressed, bDeflate.Bytes())
			decompressed.Reset()
		}
	})
	b.Run("brotli", func(b *testing.B) {
		for b.Loop() {
			WriteUnbrotli(decompressed, bBrotli.Bytes())
			decompressed.Reset()
		}
	})
	b.Run("gzip", func(b *testing.B) {
		for b.Loop() {
			WriteGunzip(decompressed, bGzip.Bytes())
			decompressed.Reset()
		}
	})
}
```

```
goos: linux
goarch: amd64
pkg: github.com/valyala/fasthttp
cpu: AMD Ryzen 5 7500F 6-Core Processor             
Benchmark_Decompress/deflate-12         	  567319	      2110 ns/op	      24 B/op	       1 allocs/op
Benchmark_Decompress/brotli-12          	  160152	      7259 ns/op	   23119 B/op	      11 allocs/op
Benchmark_Decompress/gzip-12            	  552091	      2207 ns/op	      96 B/op	       4 allocs/op
PASS
ok  	github.com/valyala/fasthttp	3.587s
```
So I made a few improvements, and now the performance is approximately on par.
```
goos: linux
goarch: amd64
pkg: github.com/valyala/fasthttp
cpu: AMD Ryzen 5 7500F 6-Core Processor             
Benchmark_Decompress/deflate-12         	  573645	      2101 ns/op	      24 B/op	       1 allocs/op
Benchmark_Decompress/brotli-12          	  482466	      2291 ns/op	      96 B/op	       4 allocs/op
Benchmark_Decompress/gzip-12            	  554427	      2165 ns/op	      96 B/op	       4 allocs/op
PASS
ok  	github.com/valyala/fasthttp	3.520s
```